### PR TITLE
Improve hero intro layout and button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@
 import { useRef, useEffect, useState } from 'react';
 import gsap from 'gsap';
 // import HeroSection from './HeroSection'; // ← пока не используем, можно убрать
-import HeroScene from './components/HeroScene';
+import HeroIntro from './components/HeroIntro';
 
 export default function App() {
   const containerRef = useRef(null);
@@ -234,7 +234,7 @@ export default function App() {
     };
   }, [section, subSection]);
 
-  // Если хотим «Погрузиться» из HeroScene и сразу перелистнуться вправо
+  // Если хотим «Погрузиться» из интро и сразу перелистнуться вправо
   const handleExploreClick = () => {
     setSection(1);
     setSubSection(0);
@@ -247,11 +247,13 @@ export default function App() {
       style={{ touchAction: 'none', userSelect: 'none' }}
     >
       <div ref={contentRef} className="flex w-[300vw]">
-        {/* 
-          Секция 1 — HeroScene (результат клика будет не scrollIntoView, а handleExploreClick)
+        {/*
+          Секция 1 — интро-анимация (результат клика будет не scrollIntoView, а handleExploreClick)
         */}
         <section className="flex-shrink-0 w-screen h-screen p-1">
-          <HeroScene onDiveComplete={handleExploreClick} />
+          <div className="w-full h-full bg-[#1D1E26] rounded-xl shadow-lg overflow-hidden">
+            <HeroIntro onDone={handleExploreClick} />
+          </div>
         </section>
 
         {/* Секция 2 */}

--- a/src/components/AnimatedButton.jsx
+++ b/src/components/AnimatedButton.jsx
@@ -1,4 +1,3 @@
-jsx
 import { useState, useEffect, useRef } from 'react';
 const AnimatedButton = ({ children, onClick, className = '' }) => {
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -7,38 +6,40 @@ const AnimatedButton = ({ children, onClick, className = '' }) => {
   const handleClick = async () => {
     if (isTransitioning) return;
     setIsTransitioning(true);
-    // Fade out all elements except the button
-    document.querySelectorAll('body > *:not(.video-overlay)').forEach(el => {
+    document.querySelectorAll('body > *:not(.video-overlay)').forEach((el) => {
       el.style.transition = 'opacity 2.5s ease-out';
       el.style.opacity = '0';
     });
-    // Show video overlay after initial fade
     setTimeout(() => {
       if (overlayRef.current) {
-        overlayRef.current.style.display = 'block';
-        if (videoRef.current) {
-          videoRef.current.play();
-        }
+        overlayRef.current.classList.remove('hidden');
+      }
+      if (videoRef.current) {
+        videoRef.current.play().catch(() => {
+          if (onClick) onClick();
+        });
+        videoRef.current.onended = () => {
+          if (onClick) onClick();
+        };
+        videoRef.current.onerror = () => {
+          if (onClick) onClick();
+        };
+      } else {
+        if (onClick) onClick();
       }
     }, 1000);
-    // Handle video completion
-    if (videoRef.current) {
-      videoRef.current.onended = () => {
-        if (onClick) onClick();
-      };
-    }
   };
   useEffect(() => {
     // Create video overlay element
     const overlay = document.createElement('div');
     overlay.className = 'video-overlay fixed top-0 left-0 w-screen h-screen hidden z-50';
-    overlay.ref = overlayRef;
+    overlayRef.current = overlay;
     const video = document.createElement('video');
     video.className = 'w-full h-full object-cover';
     video.src = '/videos/deep_anima.gif';
     video.muted = true;
     video.playsInline = true;
-    video.ref = videoRef;
+    videoRef.current = video;
     overlay.appendChild(video);
     document.body.appendChild(overlay);
     return () => {

--- a/src/components/AnimatedButton.jsx
+++ b/src/components/AnimatedButton.jsx
@@ -1,5 +1,9 @@
-import { useState, useEffect, useRef } from 'react';
-const AnimatedButton = ({ children, onClick, className = '' }) => {
+import React, { useState, useEffect, useRef, forwardRef } from 'react';
+
+const AnimatedButton = forwardRef(function AnimatedButton(
+  { children, onClick, className = '' },
+  ref,
+) {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const videoRef = useRef(null);
   const overlayRef = useRef(null);
@@ -48,6 +52,7 @@ const AnimatedButton = ({ children, onClick, className = '' }) => {
   }, []);
   return (
     <button
+      ref={ref}
       onClick={handleClick}
       disabled={isTransitioning}
       className={`
@@ -73,10 +78,9 @@ const AnimatedButton = ({ children, onClick, className = '' }) => {
         disabled:cursor-not-allowed
       `}
     >
-      <span className="relative z-10 text-white font-medium">
-        {children}
-      </span>
+      <span className="relative z-10 text-white font-medium">{children}</span>
     </button>
   );
-};
+});
+
 export default AnimatedButton;

--- a/src/components/HeroIntro.jsx
+++ b/src/components/HeroIntro.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef } from 'react';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import AnimatedButton from './AnimatedButton';
+
+gsap.registerPlugin(ScrollTrigger);
+
+export default function HeroIntro({ onDone }) {
+  const containerRef = useRef(null);
+  const lettersRef = useRef([]);
+  const planetRef = useRef(null);
+  const servicesRef = useRef([]);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      const tl = gsap.timeline();
+      tl.set(containerRef.current, { opacity: 0 })
+        .set(planetRef.current, { y: 100, scale: 0.8, opacity: 0 })
+        .set(lettersRef.current, { opacity: 0, y: 20 })
+        .to(containerRef.current, { opacity: 1, duration: 1 })
+        .to(lettersRef.current, {
+          opacity: 1,
+          y: 0,
+          stagger: 0.05,
+          duration: 0.6,
+          ease: 'power3.out',
+        })
+        .fromTo(
+          planetRef.current,
+          { y: 100, opacity: 0, scale: 0.8 },
+          { y: 0, opacity: 1, scale: 1, duration: 1, ease: 'power3.out' }
+        );
+
+      const serviceTl = gsap.timeline({
+        scrollTrigger: {
+          trigger: containerRef.current,
+          start: 'top top',
+          end: '+=1000',
+          scrub: true,
+          pin: true,
+        },
+      });
+
+      serviceTl
+        .to(lettersRef.current, {
+          y: (i) => (i % 2 === 0 ? -80 : 80),
+          scale: 0.8,
+          duration: 1,
+          stagger: 0.1,
+        })
+        .fromTo(
+          servicesRef.current,
+          { opacity: 0, y: 30 },
+          {
+            opacity: 1,
+            y: 0,
+            duration: 0.8,
+            stagger: 0.2,
+          },
+          '-=0.5'
+        );
+    }, containerRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  const letters = ['G', 'r', 'a', 'v', 'i', 'C', 'o'];
+  const services = [
+    { img: '/images/hero/consultation.png', label: 'Консультации' },
+    { img: '/images/hero/offline.png', label: 'Оффлайн обучение' },
+    { img: '/images/hero/audit.png', label: 'Аудиты' },
+    { img: '/images/hero/seo.png', label: 'SEO' },
+    { img: '/images/hero/online.png', label: 'Онлайн курсы' },
+  ];
+
+  return (
+    <section
+      ref={containerRef}
+      className="relative w-full h-full overflow-hidden bg-[#1D1E26] flex flex-col items-center justify-center"
+    >
+      <div className="absolute inset-0 bg-center bg-cover opacity-0" style={{ backgroundImage: "url('/images/parallax-bg.jpg')" }} />
+      <h1 className="text-white text-5xl md:text-7xl font-extrabold flex space-x-1 text-center">
+        {letters.map((ch, i) => (
+          <span
+            key={i}
+            ref={(el) => (lettersRef.current[i] = el)}
+            className="inline-block"
+          >
+            {ch}
+          </span>
+        ))}
+      </h1>
+      <p className="text-gray-300 mt-4 text-lg md:text-2xl">Маркетинг с погружением</p>
+      <img
+        ref={planetRef}
+        src="/images/hero/planet.png"
+        alt="planet"
+        className="w-48 md:w-72 mt-10"
+      />
+
+      <div className="grid grid-cols-5 gap-4 mt-20 w-full max-w-4xl mx-auto">
+        {services.map((s, i) => (
+          <div
+            key={i}
+            ref={(el) => (servicesRef.current[i] = el)}
+            className="flex flex-col items-center opacity-0"
+          >
+            <img src={s.img} alt="" className="w-16 mb-2" />
+            <span className="text-sm text-gray-300">{s.label}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-16">
+        <AnimatedButton ref={buttonRef} onClick={onDone}>Погрузиться</AnimatedButton>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap `HeroIntro` with same card style as other sections
- enlarge and center hero text/planet
- fix `AnimatedButton` refs and fallback to ensure callback triggers

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684175755b3083268c16234d2406795a